### PR TITLE
8.3.2.0

### DIFF
--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
@@ -55,6 +55,11 @@
   if (!strongConnector || !strongAdapter) {
     return;
   }
+    
+  if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+      NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+      return;
+  }
 
   NSString *appID = [strongConnector.credentials[kGADMAdapterChartboostAppID]
       stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
@@ -57,7 +57,9 @@
   }
     
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSString* logError =
+      [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
+       kGADMAdapterMinimumOSVersion];
     NSLog(@"%@", logError);
     [strongConnector adapter:strongAdapter didFailAd:GADChartboostErrorWithDescription(logError)];
     return;

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostBannerAd.m
@@ -57,8 +57,10 @@
   }
     
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-      NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
-      return;
+    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSLog(@"%@", logError);
+    [strongConnector adapter:strongAdapter didFailAd:GADChartboostErrorWithDescription(logError)];
+    return;
   }
 
   NSString *appID = [strongConnector.credentials[kGADMAdapterChartboostAppID]

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 /// Chartboost mediation network adapter version.
-static NSString *const kGADMAdapterChartboostVersion = @"8.2.1.0";
+static NSString *const kGADMAdapterChartboostVersion = @"8.3.2.0";
 
 /// Chartboost App ID.
 static NSString *const kGADMAdapterChartboostAppID = @"appId";
@@ -28,3 +28,6 @@ static NSString *const kGADMAdapterChartboostAdLocation = @"adLocation";
 
 /// Chartboost adapter error domain.
 static NSString *const kGADMAdapterChartboostErrorDomain = @"com.google.mediation.chartboost";
+
+/// Minimum OS version.
+static NSString *const kGADMAdapterMinimumOSVersion = @"10.0";

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
@@ -58,7 +58,9 @@
   }
 
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSLog(@"%@", logError);
+    [strongConnector adapter:strongAdapter didFailAd:GADChartboostErrorWithDescription(logError)];
     return;
   }
     

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
@@ -58,7 +58,9 @@
   }
 
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSString* logError =
+      [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
+       kGADMAdapterMinimumOSVersion];
     NSLog(@"%@", logError);
     [strongConnector adapter:strongAdapter didFailAd:GADChartboostErrorWithDescription(logError)];
     return;

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostInterstitialAd.m
@@ -57,6 +57,11 @@
     return;
   }
 
+  if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    return;
+  }
+    
   NSString *appID = [strongConnector.credentials[kGADMAdapterChartboostAppID]
       stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
   NSString *appSignature = [strongConnector.credentials[kGADMAdapterChartboostAppSignature]

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -84,7 +84,9 @@
   }
 
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSString* logError =
+      [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
+       kGADMAdapterMinimumOSVersion];
     NSLog(@"%@", logError);
     _completionHandler(nil, GADChartboostErrorWithDescription(logError));
     return;

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -83,6 +83,11 @@
     return;
   }
 
+  if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    return;
+  }
+    
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
   GADMAdapterChartboostRewardedAd *weakSelf = self;
   [Chartboost

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -84,7 +84,9 @@
   }
 
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSLog(@"%@", logError);
+    _completionHandler(nil, GADChartboostErrorWithDescription(logError));
     return;
   }
     

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.h
@@ -20,6 +20,8 @@
 #import <Foundation/Foundation.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 /// Sets |value| for |key| in |dictionary| if |value| is not nil.
 void GADMAdapterChartboostMutableDictionarySetObjectForKey(NSMutableDictionary *_Nonnull dictionary,
                                                            id<NSCopying> _Nullable key,

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -32,7 +32,9 @@
 + (void)setUpWithConfiguration:(GADMediationServerConfiguration *)configuration
              completionHandler:(GADMediationAdapterSetUpCompletionBlock)completionHandler {    
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSString* logError =
+      [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
+       kGADMAdapterMinimumOSVersion];
     NSLog(@"%@", logError);
     completionHandler(GADChartboostErrorWithDescription(logError));
     return;

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -32,7 +32,9 @@
 + (void)setUpWithConfiguration:(GADMediationServerConfiguration *)configuration
              completionHandler:(GADMediationAdapterSetUpCompletionBlock)completionHandler {    
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    NSString* log = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSLog(@"%@", log);
+    completionHandler(GADChartboostErrorWithDescription(log));
     return;
   }
     

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -32,9 +32,9 @@
 + (void)setUpWithConfiguration:(GADMediationServerConfiguration *)configuration
              completionHandler:(GADMediationAdapterSetUpCompletionBlock)completionHandler {    
   if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-    NSString* log = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
-    NSLog(@"%@", log);
-    completionHandler(GADChartboostErrorWithDescription(log));
+    NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion];
+    NSLog(@"%@", logError);
+    completionHandler(GADChartboostErrorWithDescription(logError));
     return;
   }
     

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -30,7 +30,12 @@
 }
 
 + (void)setUpWithConfiguration:(GADMediationServerConfiguration *)configuration
-             completionHandler:(GADMediationAdapterSetUpCompletionBlock)completionHandler {
+             completionHandler:(GADMediationAdapterSetUpCompletionBlock)completionHandler {    
+  if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+    NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    return;
+  }
+    
   NSMutableDictionary *credentials = [[NSMutableDictionary alloc] init];
 
   for (GADMediationCredentials *cred in configuration.credentials) {


### PR DESCRIPTION
Checking Chartboost minimum iOS version available to prevent making calls that would expect a callback.